### PR TITLE
ci: install poetry export plugin for poetry 2.x

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,10 +78,6 @@ jobs:
       with:
         poetry-version: '2.3.2'
 
-    - name: Install Poetry export plugin
-      run: |
-        poetry self add poetry-plugin-export
-
     - name: Bind Poetry to Python 3.11
       run: |
         poetry env use 3.11
@@ -112,6 +108,10 @@ jobs:
       uses: abatilo/actions-poetry@v4
       with:
         poetry-version: '2.3.2'
+
+    - name: Install Poetry export plugin
+      run: |
+        poetry self add poetry-plugin-export
 
     - name: Bind Poetry to Python 3.11
       run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,6 +78,10 @@ jobs:
       with:
         poetry-version: '2.3.2'
 
+    - name: Install Poetry export plugin
+      run: |
+        poetry self add poetry-plugin-export
+
     - name: Bind Poetry to Python 3.11
       run: |
         poetry env use 3.11

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,6 +26,10 @@ jobs:
         with:
           poetry-version: '2.3.2'
 
+      - name: Install Poetry export plugin
+        run: |
+          poetry self add poetry-plugin-export
+
       - name: Install dependencies
         run: |
           poetry install --with dev --no-interaction

--- a/src/ab_glm/pipeline.py
+++ b/src/ab_glm/pipeline.py
@@ -105,21 +105,27 @@ def simulate_ab_data(
 
     # Vectorized session expansion to avoid Python-level nested loops.
     n_sessions_user = rng.integers(lo, hi + 1, size=n_users)
-    user_id = np.repeat(np.arange(n_users), n_sessions_user)
+    user_id = np.repeat(np.arange(n_users, dtype=np.int32), n_sessions_user)
 
     eta_base = (
         -2.0 + 0.20 * country_EU + 0.25 * device_mobile + 0.08 * prior_views + 0.35 * T_user + u
     )
     p_user = 1.0 / (1.0 + np.exp(-eta_base))  # logistic to generate outcomes
-    y = rng.binomial(1, p_user[user_id])
+    # Expand user-level features once; this is faster than repeated fancy indexing.
+    t_rep = np.repeat(T_user, n_sessions_user)
+    country_rep = np.repeat(country_EU, n_sessions_user)
+    mobile_rep = np.repeat(device_mobile, n_sessions_user)
+    views_rep = np.repeat(prior_views, n_sessions_user)
+    p_rep = np.repeat(p_user, n_sessions_user)
+    y = rng.binomial(1, p_rep)
 
     df = pd.DataFrame(
         {
             "user_id": user_id,
-            "T": T_user[user_id],
-            "country_EU": country_EU[user_id],
-            "device_mobile": device_mobile[user_id],
-            "prior_views": prior_views[user_id],
+            "T": t_rep,
+            "country_EU": country_rep,
+            "device_mobile": mobile_rep,
+            "prior_views": views_rep,
             "y": y,
         }
     )

--- a/src/ab_glm/pipeline.py
+++ b/src/ab_glm/pipeline.py
@@ -103,25 +103,25 @@ def simulate_ab_data(
     # Random intercept (user-level latent propensity)
     u = rng.normal(0.0, 0.5, size=n_users)
 
-    rows = []
-    for i in range(n_users):
-        n_sessions = rng.integers(lo, hi + 1)
-        eta_base = (
-            -2.0
-            + 0.20 * country_EU[i]
-            + 0.25 * device_mobile[i]
-            + 0.08 * prior_views[i]
-            + 0.35 * T_user[i]
-            + u[i]
-        )
-        p = 1.0 / (1.0 + np.exp(-eta_base))  # logistic to generate outcomes
-        for _ in range(n_sessions):
-            y = rng.binomial(1, p)
-            rows.append((i, T_user[i], country_EU[i], device_mobile[i], prior_views[i], y))
+    # Vectorized session expansion to avoid Python-level nested loops.
+    n_sessions_user = rng.integers(lo, hi + 1, size=n_users)
+    user_id = np.repeat(np.arange(n_users), n_sessions_user)
+
+    eta_base = (
+        -2.0 + 0.20 * country_EU + 0.25 * device_mobile + 0.08 * prior_views + 0.35 * T_user + u
+    )
+    p_user = 1.0 / (1.0 + np.exp(-eta_base))  # logistic to generate outcomes
+    y = rng.binomial(1, p_user[user_id])
 
     df = pd.DataFrame(
-        rows,
-        columns=["user_id", "T", "country_EU", "device_mobile", "prior_views", "y"],
+        {
+            "user_id": user_id,
+            "T": T_user[user_id],
+            "country_EU": country_EU[user_id],
+            "device_mobile": device_mobile[user_id],
+            "prior_views": prior_views[user_id],
+            "y": y,
+        }
     )
     return df
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Install `poetry-plugin-export` across CI (including the security job) and release workflows to restore `poetry export` on Poetry 2.x and avoid failures, and vectorize A/B data simulation to speed up session generation.

<sup>Written for commit b0e3a89f474f73cfc0edc5ab440aac1e784e2b02. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

